### PR TITLE
Do not search template’s content as location

### DIFF
--- a/grails-app/services/org/tinker/handlebars/HandlebarsService.groovy
+++ b/grails-app/services/org/tinker/handlebars/HandlebarsService.groovy
@@ -112,7 +112,7 @@ class HandlebarsService implements ServletContextAware {
             text = t
         }
 
-        def template = handlebars.compile(text)
+        def template = handlebars.compileInline(text)
         if (templateCache != null) templateCache.put(t, template)
         return template
     }


### PR DESCRIPTION
Hi, David

We found a problem while trying to render from a template. It looks like its trying to render the content of the template as a location.
